### PR TITLE
Fixes for private arrays, formatting in staticweapons

### DIFF
--- a/addons/staticweapons/CfgVehicles.hpp
+++ b/addons/staticweapons/CfgVehicles.hpp
@@ -504,7 +504,7 @@ class CfgVehicles
                 distance = 5;
                 priority = 2;
                 class 16aa_Disassemble{
-                     distance = 5;
+                    distance = 5;
                     displayName = "Disassemble L16";
                     condition = QUOTE([ARR_2(_target,_player)] call FUNC(canDisassemble));
                     statement = QUOTE([ARR_4(_target,_player,'16aa_l16_baseplate_deployed',['16aa_static_item_l16_tube'])] call FUNC(disassembleTimer));
@@ -761,7 +761,7 @@ class CfgVehicles
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class 16aa_AdjustHeightUp_L2A1{
-                     condition = "false";
+                    condition = "false";
                 };
                 class 16aa_AdjustHeightUp_L2A1_Down: 16aa_AdjustHeightUp_L2A1{
                     displayName = "Lower Tripod";
@@ -888,7 +888,7 @@ class CfgVehicles
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class 16aa_AdjustHeightUp_GMG{
-                     condition = "false";
+                    condition = "false";
                 };
                 class 16aa_AdjustHeightDown_GMG: 16aa_AdjustHeightUp_GMG{
                     displayName = "Lower Tripod";
@@ -990,7 +990,7 @@ class CfgVehicles
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class 16aa_AdjustHeightUp_GPMG{
-                     condition = "false";
+                    condition = "false";
                 };
                 class 16aa_AdjustHeightDown_GPMG: 16aa_AdjustHeightUp_GPMG{
                     displayName = "Lower Tripod";
@@ -1092,7 +1092,7 @@ class CfgVehicles
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class 16aa_AdjustHeightUp_Javelin{
-                     condition = "false";
+                    condition = "false";
                 };
                 class 16aa_AdjustHeightDown_Javelin: 16aa_AdjustHeightUp_Javelin{
                     displayName = "Lower Tripod";

--- a/addons/staticweapons/CfgWeapons.hpp
+++ b/addons/staticweapons/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
         model = "\16aa_weapons_support\Tripod\tripod_item.p3d";
         picture = PATHTOF(UI\w_tripod_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 130;
         };
     };
@@ -24,7 +24,7 @@ class CfgWeapons {
         model = PATHTOF(data\l2a1_barrel.p3d);
         picture = PATHTOF(UI\w_l2a1_barrel_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 130;
         };
     };
@@ -37,7 +37,7 @@ class CfgWeapons {
         model = PATHTOF(data\l2a1_receiver.p3d);
         picture = PATHTOF(UI\w_l2a1_receiver_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 140;
         };
     };
@@ -50,7 +50,7 @@ class CfgWeapons {
         model = PATHTOF(data\gmg_barrel.p3d);
         picture = PATHTOF(UI\w_gmg_barrel_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 130;
         };
     };
@@ -63,7 +63,7 @@ class CfgWeapons {
         model = PATHTOF(data\gmg_receiver.p3d);
         picture = PATHTOF(UI\w_gmg_receiver_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 140;
         };
     };
@@ -76,7 +76,7 @@ class CfgWeapons {
         model = PATHTOF(data\l16_baseplate.p3d);
         picture = PATHTOF(UI\w_l16_baseplate_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 150;
         };
     };
@@ -89,7 +89,7 @@ class CfgWeapons {
         model = PATHTOF(data\l16_bipod.p3d);
         picture = PATHTOF(UI\w_l16_bipod_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 150;
         };
     };
@@ -102,7 +102,7 @@ class CfgWeapons {
         model = PATHTOF(data\l16_tube.p3d);
         picture = PATHTOF(UI\w_l16_tube_ca.paa);
         magazines[] = {};
-         class ItemInfo: InventoryItem_Base_F {
+        class ItemInfo: InventoryItem_Base_F {
             mass = 150;
         };
     };

--- a/addons/staticweapons/functions/fnc_adjustHeight.sqf
+++ b/addons/staticweapons/functions/fnc_adjustHeight.sqf
@@ -17,12 +17,12 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_staticNewClass","_unit"];
+params ["_staticOld","_staticNewClass","_unit"];
 
 [{
     params["_staticOld","_staticNewClass","_unit"];
 
-    private ["_direction,_position,_staticNew,_hasBarrelV,_configBarrel,_currentMagazine,_ammoCount,_hasMagazine,_defaultMag"];
+    private ["_direction","_position","_staticNew","_hasBarrelV","_configBarrel","_currentMagazine","_ammoCount","_hasMagazine","_defaultMag"];
     _direction = getDir _staticOld;
     _position = getPosASL _staticOld;
 

--- a/addons/staticweapons/functions/fnc_adjustHeightTimer.sqf
+++ b/addons/staticweapons/functions/fnc_adjustHeightTimer.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_staticNewClass","_unit"];
+params ["_staticOld","_staticNewClass","_unit"];
 
 private ["_name", "_progressText"];
 //Get displayname of the new static weapon to be created. Used for progress bar text

--- a/addons/staticweapons/functions/fnc_assemble.sqf
+++ b/addons/staticweapons/functions/fnc_assemble.sqf
@@ -18,7 +18,7 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_unit","_staticNewClass","_staticItem"];
+params ["_staticOld","_unit","_staticNewClass","_staticItem"];
 
 //If staticItem is of a specific type then use the correct method to remove that item
 _staticItemType = [_staticItem] call ace_common_fnc_getWeaponType;
@@ -31,7 +31,7 @@ if (_staticItemtype == -1) then {
 [{
     params["_staticOld","_unit","_staticNewClass","_staticItem"];
 
-     private ["_direction,_position,_configBarrel"];
+     private ["_direction","_position","_configBarrel"];
      //Get position of object called when assembling then delete it
     _direction = getDir _staticOld;
     _position = getPosASL _staticOld;

--- a/addons/staticweapons/functions/fnc_assembleTimer.sqf
+++ b/addons/staticweapons/functions/fnc_assembleTimer.sqf
@@ -18,7 +18,7 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_unit","_staticNewClass","_staticItem"];
+params ["_staticOld","_unit","_staticNewClass","_staticItem"];
 private ["_name", "_progressText"];
 //Get displayname of the new static weapon to be spawned to be used in the progress bar text
 _name = getText (configFile >> "CfgVehicles" >> _staticNewClass >> "displayName");

--- a/addons/staticweapons/functions/fnc_canAdjustHeight.sqf
+++ b/addons/staticweapons/functions/fnc_canAdjustHeight.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
+params ["_static","_unit"];
 private "_canAdjustHeight";
 
 _canAdjustHeight = false;

--- a/addons/staticweapons/functions/fnc_canDisassemble.sqf
+++ b/addons/staticweapons/functions/fnc_canDisassemble.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
+params ["_static","_unit"];
 private "_canDisassemble";
 
 _canDisassemble = false;

--- a/addons/staticweapons/functions/fnc_canDismountBarrel.sqf
+++ b/addons/staticweapons/functions/fnc_canDismountBarrel.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
+params ["_static","_unit"];
 private "_canDismountBarrel";
 
 _canDismountBarrel = false;

--- a/addons/staticweapons/functions/fnc_canLoadMagazine.sqf
+++ b/addons/staticweapons/functions/fnc_canLoadMagazine.sqf
@@ -18,8 +18,8 @@
 
 #include "script_component.hpp"
 
-params["_static","_unit","_magazineClassOptional"];
-private "_canLoadMagazine,_currentMagazine,_weapon,_magazines,_listOfMagNames,_hasCompatibleMagazine,_hasBarrel,_count,_parsed";
+params ["_static","_unit","_magazineClassOptional"];
+private ["_canLoadMagazine","_currentMagazine","_weapon","_magazines","_listOfMagNames","_hasCompatibleMagazine","_hasBarrel","_count","_parsed"];
 
 _canLoadMagazine = false;
 _currentMagazine = (magazinesAllTurrets _static) select 1;

--- a/addons/staticweapons/functions/fnc_canMountBarrel.sqf
+++ b/addons/staticweapons/functions/fnc_canMountBarrel.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_barrelClass"];
+params ["_static","_unit","_barrelClass"];
 private "_canMountBarrel";
 
 _canMountBarrel = false;

--- a/addons/staticweapons/functions/fnc_canUnloadMagazine.sqf
+++ b/addons/staticweapons/functions/fnc_canUnloadMagazine.sqf
@@ -16,8 +16,8 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
-private "_canUnloadMagazine,_hasBarrel";
+params ["_static","_unit"];
+private ["_canUnloadMagazine","_hasBarrel"];
 
 _canUnloadMagazine = false;
 _hasBarrel = _static getVariable [QGVAR(hasBarrel),true];

--- a/addons/staticweapons/functions/fnc_disassemble.sqf
+++ b/addons/staticweapons/functions/fnc_disassemble.sqf
@@ -18,12 +18,12 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_unit","_staticNewClass","_staticItems"];
+params ["_staticOld","_unit","_staticNewClass","_staticItems"];
 
 [{
     params["_staticOld","_unit","_staticNewClass","_staticItems"];
 
-     private ["_direction", "_position"];
+    private ["_direction", "_position"];
     //Get position of old static weapon then delete it
     _direction = getDir _staticOld;
     _position = getPosASL _staticOld;

--- a/addons/staticweapons/functions/fnc_disassembleTimer.sqf
+++ b/addons/staticweapons/functions/fnc_disassembleTimer.sqf
@@ -18,8 +18,8 @@
  */
 #include "script_component.hpp"
 
-params["_staticOld","_unit","_staticNewClass","_staticItems"];
-private ["_name, _progressText, _objectClassName"];
+params ["_staticOld","_unit","_staticNewClass","_staticItems"];
+private ["_name", "_progressText", "_objectClassName"];
 
 //Get displayname of static weapon to be created. Used for progress bar text
 _objectClassName = typeOf _staticOld;

--- a/addons/staticweapons/functions/fnc_dismountBarrel.sqf
+++ b/addons/staticweapons/functions/fnc_dismountBarrel.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_barrelClass"];
+params ["_static","_unit","_barrelClass"];
 
 //Add barrel item to player inventory
 [_unit, _barrelClass] call ace_common_fnc_addToInventory;

--- a/addons/staticweapons/functions/fnc_dismountBarrelTimer.sqf
+++ b/addons/staticweapons/functions/fnc_dismountBarrelTimer.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_barrelClass"];
+params ["_static","_unit","_barrelClass"];
 
 _progressText = "Detatching Barrel";
 

--- a/addons/staticweapons/functions/fnc_handleFiredMortar.sqf
+++ b/addons/staticweapons/functions/fnc_handleFiredMortar.sqf
@@ -22,7 +22,7 @@
 
 #include "script_component.hpp"
 params ["_vehicle","_weapon","_muzzle","_mode","_ammo","_magazine","_projectile"];
-private ["_static,_magazineName","_count"];
+private ["_static","_magazineName","_count"];
 _static = _this select 0;
 _magazineName = _this select 5;
 //Get ammo count of loaded magazine

--- a/addons/staticweapons/functions/fnc_loadMagazine.sqf
+++ b/addons/staticweapons/functions/fnc_loadMagazine.sqf
@@ -17,8 +17,8 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_magazineClassOptional"];
-private "_weapon,_currentMagazine,_count,_magazines,_magazineDetails,_listOfMagNames,_magazineClass,_magazineClassDetails,_parsed,_roundsLeft,_configMortar";
+params ["_static","_unit","_magazineClassOptional"];
+private ["_weapon","_currentMagazine","_count","_magazines","_magazineDetails","_listOfMagNames","_magazineClass","_magazineClassDetails","_parsed","_roundsLeft","_configMortar"];
 
 //Get weapon & magazine information of static weapon
 _weapon = (_static weaponsTurret [0]) select 0;

--- a/addons/staticweapons/functions/fnc_loadMagazineTimer.sqf
+++ b/addons/staticweapons/functions/fnc_loadMagazineTimer.sqf
@@ -17,9 +17,9 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_magazineClassOptional","_timeToLoad"];
+params ["_static","_unit","_magazineClassOptional","_timeToLoad"];
 
-_progressText = "Loading Magazine";
+private _progressText = "Loading Magazine";
 //Move player into animation if player is standing
 if ((_unit call CBA_fnc_getUnitAnim) select 0 == "stand") then {
     [_unit, "AmovPercMstpSrasWrflDnon_diary", 1] call ace_common_fnc_doAnimation;

--- a/addons/staticweapons/functions/fnc_mountBarrel.sqf
+++ b/addons/staticweapons/functions/fnc_mountBarrel.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_barrelClass"];
+params ["_static","_unit","_barrelClass"];
 //Remove barrel item to players inventory
 _unit removeItem _barrelClass;
 

--- a/addons/staticweapons/functions/fnc_mountBarrelTimer.sqf
+++ b/addons/staticweapons/functions/fnc_mountBarrelTimer.sqf
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit","_barrelClass"];
+params ["_static","_unit","_barrelClass"];
 
 _progressText = "Attaching Barrel";
 

--- a/addons/staticweapons/functions/fnc_pickup.sqf
+++ b/addons/staticweapons/functions/fnc_pickup.sqf
@@ -18,9 +18,9 @@
  */
 #include "script_component.hpp"
 
-params["_vehicle","_unit","_staticItem"];
+params ["_vehicle","_unit","_staticItem"];
 [{
-    params["_vehicle","_unit","_staticItem"];
+    params ["_vehicle","_unit","_staticItem"];
 
     //Add item to players inventory and delete the static weapon
     [_unit, _staticItem] call ace_common_fnc_addToInventory;

--- a/addons/staticweapons/functions/fnc_pickupTimer.sqf
+++ b/addons/staticweapons/functions/fnc_pickupTimer.sqf
@@ -18,8 +18,8 @@
  */
 #include "script_component.hpp"
 
-params["_vehicle","_unit","_staticItem"];
-private ["_name, _progressText, _objectClassName"];
+params ["_vehicle","_unit","_staticItem"];
+private ["_name", "_progressText", "_objectClassName"];
 
 //Get displayname of static weapon to be picked up. Used for progress bar text
 _objectClassName = typeOf _vehicle;

--- a/addons/staticweapons/functions/fnc_place.sqf
+++ b/addons/staticweapons/functions/fnc_place.sqf
@@ -18,14 +18,14 @@
  */
 #include "script_component.hpp"
 
-params["_unit","_itemClass","_vehicleClass"];
+params ["_unit","_itemClass","_vehicleClass"];
 
 //Remove item needed to assemble static weapon
 _unit removeItem _itemClass;
 
 [{
-    params["_unit","_vehicleClass"];
-    private ["_direction, _position, _vehicle"];
+    params ["_unit","_vehicleClass"];
+    private ["_direction", "_position"," _vehicle"];
 
     //Get position of the player
     _direction = getDir _unit;

--- a/addons/staticweapons/functions/fnc_placeTimer.sqf
+++ b/addons/staticweapons/functions/fnc_placeTimer.sqf
@@ -18,8 +18,8 @@
  */
 #include "script_component.hpp"
 
-params["_unit","_itemClass","_vehicleClass"];
-private ["_name, _progressText"];
+params ["_unit","_itemClass","_vehicleClass"];
+private ["_name"," _progressText"];
 
 //Get displayname of the static weapon to be created. Used in progress bar text
 _name = getText (configFile >> "CfgVehicles" >> _vehicleClass >> "displayName");

--- a/addons/staticweapons/functions/fnc_unloadMagazine.sqf
+++ b/addons/staticweapons/functions/fnc_unloadMagazine.sqf
@@ -17,8 +17,8 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
-private "_weapon,_currentMagazine,_currentMagazineClass,_ammoCount";
+params ["_static","_unit"];
+private ["_weapon","_currentMagazine","_currentMagazineClass","_ammoCount"];
 
 //Get weapon & magazine information about static weapon
 _weapon = (_static weaponsTurret [0]) select 0;

--- a/addons/staticweapons/functions/fnc_unloadMagazineTimer.sqf
+++ b/addons/staticweapons/functions/fnc_unloadMagazineTimer.sqf
@@ -17,9 +17,9 @@
  */
 #include "script_component.hpp"
 
-params["_static","_unit"];
+params ["_static","_unit"];
 
-_progressText = "Unloading Magazine";
+private _progressText = "Unloading Magazine";
 
 //Move player into animation if player is standing
 if ((_unit call CBA_fnc_getUnitAnim) select 0 == "stand") then {


### PR DESCRIPTION
Almost all the private arrays in staticweapons were non-functional. Some other formatting cleaned up as well.
